### PR TITLE
Find alias_arn which alias name equal to arn_qualifier  in the aliasList

### DIFF
--- a/gg_group_setup/cmd.py
+++ b/gg_group_setup/cmd.py
@@ -242,14 +242,15 @@ class GroupCommands(object):
             lambda_name = key
             try:
                 a = aws.list_aliases(FunctionName=lambda_name)
-                # assume only one Alias associated with the Lambda function
-                alias_arn = a['Aliases'][0]['AliasArn']
+                q = config['lambda_functions'][lambda_name]['arn_qualifier']
+                # Find the alias index in alias list which alias name equal to arn_qualifier
+                alias_index = next((index for (index, d) in enumerate(a['Aliases']) if d["Name"] == q))
+                alias_arn = a['Aliases'][alias_index]['AliasArn']
                 logging.info("function {0}, found aliases: {1}".format(
                     lambda_name, a)
                 )
 
                 # get the function pointed to by the alias
-                q = config['lambda_functions'][lambda_name]['arn_qualifier']
                 f = aws.get_function(FunctionName=lambda_name, Qualifier=q)
                 logging.info(
                     "retrieved func config: {0}".format(f['Configuration']))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In _create_function_definition, it will get index 0 of alias name to override config['lambda_functions'].
I change it to find alias_arn which alias name equal to arn_qualifier in the aliasList so that it can find correct one alias_arn with multiple alias.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
