### PR TITLE
Issue #22: Added support for greengrass group lambda environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Lambda function(s)
               "<function_name>": {
                 "arn": "<lambda_ARN>",
                 "arn_qualifier": "<alias>"
+                "environment_variables": {
+                  "<name>": "<value>",
+                }
               }
             },
             ```
@@ -83,6 +86,9 @@ Lambda function(s)
               "MyFirstGreengrassLambda": {
                 "arn": "arn:aws:lambda:us-west-2:<account_id>:function:MyFirstGreengrassLambda:dev",
                 "arn_qualifier": "dev"
+                "environment_variables": {
+                  "SAY_HELLO_TO": "Miss. Mocking Bird",
+                }
               }
             },
             ```
@@ -95,10 +101,17 @@ Lambda function(s)
                   "MyFirstGreengrassLambda": {
                     "arn": "arn:aws:lambda:us-west-2:<account_id>:function:MyFirstGreengrassLambda:dev",
                     "arn_qualifier": "dev"
+                    "environment_variables": {
+                      "SAY_HELLO_TO": "Miss. Mocking Bird",
+                    }
                   },
                   "MockDeviceLambda": {
                     "arn": "arn:aws:lambda:us-west-2:<account_id>:function:MockDeviceLambda:dev",
                     "arn_qualifier": "dev"
+                    "environment_variables": {
+                      "SAY_GOODBYE_TO": "Mr. Sleepy Owl",
+                      "SAY_GOODBYE_AT": "8:00 PM",
+                    }
                   }
                 },
                 ```

--- a/gg_group_setup/cfg.json
+++ b/gg_group_setup/cfg.json
@@ -21,22 +21,26 @@
       "thing_name": ""
     }
   },
-  "func_def": {
-    "id": "",
-    "version_arn": ""
-  },
+    "func_def": {
+        "id": "",
+      "version_arn": "",
+      "environment_variables": {}
+    },
   "group": {
     "id": "",
     "name": "fubar-neel",
     "version": "",
     "version_arn": ""
   },
-  "lambda_functions": {
-    "MockDevice": {
-      "arn": "arn:aws:lambda:us-west-2:<account_id>:function:MockDevice:<alias>",
-      "arn_qualifier": "<alias>"
-    }
-  },
+    "lambda_functions": {
+        "MockDevice": {
+            "arn": "arn:aws:lambda:us-west-2:<account_id>:function:MockDevice:<alias>",
+            "arn_qualifier": "<alias>",
+            "environment_variables": {
+               "<name>": "<value>",
+            }
+        }
+    },
   "logger_def": {
     "id": "",
     "version_arn": ""

--- a/gg_group_setup/cmd.py
+++ b/gg_group_setup/cmd.py
@@ -250,18 +250,29 @@ class GroupCommands(object):
                     lambda_name, a)
                 )
 
+                # add environment variables to lambda function definition
+                environment_variables =  config['lambda_functions'][lambda_name]['environment_variables']
+                logging.info('function {0}, adding environment variables: {1}'.format(
+                    lambda_name, json.dumps(environment_variables)
+                ))
+
                 # get the function pointed to by the alias
                 f = aws.get_function(FunctionName=lambda_name, Qualifier=q)
                 logging.info(
                     "retrieved func config: {0}".format(f['Configuration']))
                 latest_funcs[lambda_name] = {
                     "arn": alias_arn,
-                    "arn_qualifier": q
+                    "arn_qualifier": q,
+                    "environment_variables": environment_variables
                 }
+
                 func_definition.append({
                     "Id": "{0}".format(lambda_name.lower()),
                     "FunctionArn": alias_arn,
                     "FunctionConfiguration": {
+                        "Environment": {
+                            "Variables": environment_variables
+                         },
                         "Executable": f['Configuration']['Handler'],
                         "MemorySize":
                             int(f['Configuration']['MemorySize']) * 1000,
@@ -284,7 +295,7 @@ class GroupCommands(object):
             config['lambda_functions'] = latest_funcs
             ll_arn = lmbv['Arn']
             logging.info("Created Function definition ARN:{0}".format(ll_arn))
-            config['func_def'] = {'id': ll['Id'], 'version_arn': ll_arn}
+            config['func_def'] = {'id': ll['Id'], 'version_arn': ll_arn, 'environment_variables': environment_variables}
             return ll_arn
         else:
             return


### PR DESCRIPTION
Issue #22

Added support for greengrass group lambda environment variables.

Usage: 

Add your environment variables to `lambda_functions` as follows: 

```
{
...
    "lambda_functions": {
        "MockDevice": {
            "arn": "arn:aws:lambda:us-west-2:<account_id>:function:MockDevice:<alias>",
            "arn_qualifier": "<alias>",
            "environment_variables": {
               "<name>": "<value>",
            }
        }
    },
...
}
```

And then run `gg_group_setup create`. 

And your greengrass lambda function defintion will now have the environment variables specified.

The same environment variables will also be reflected in the json config file (cfg.json) under `func_defs` as follows:

```
{
...
    func_def: {
        "environment_variables": {
               "<name>": "<value>",
        }
    }
...
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
