### PR TITLE
Removed typo "," in line 40

### DIFF
--- a/gg_group_setup/cfg.json
+++ b/gg_group_setup/cfg.json
@@ -37,7 +37,7 @@
             "arn": "arn:aws:lambda:us-west-2:<account_id>:function:MockDevice:<alias>",
             "arn_qualifier": "<alias>",
             "environment_variables": {
-               "<name>": "<value>",
+               "<name>": "<value>"
             }
         }
     },


### PR DESCRIPTION


*Issue #, if available:*
The "," in line 40 was resulting in an error when calling "gg_group_setup create-core":
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 41 column 13 (char 824)


*Description of changes:*
Removed typo "," in line 40

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
